### PR TITLE
Support for dynamic notification definitions

### DIFF
--- a/aspnet-core/LINGYUN.MicroService.All.sln
+++ b/aspnet-core/LINGYUN.MicroService.All.sln
@@ -464,7 +464,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LINGYUN.Abp.Notifications.P
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "realtime", "realtime", "{ECC8B9A9-9E92-4493-984D-2E350A49189D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINGYUN.Abp.Notifications.Core", "modules\common\LINGYUN.Abp.Notifications.Core\LINGYUN.Abp.Notifications.Core.csproj", "{62971DAE-CE71-4E9C-B6F5-514C8E2B915C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LINGYUN.Abp.Notifications.Core", "modules\common\LINGYUN.Abp.Notifications.Core\LINGYUN.Abp.Notifications.Core.csproj", "{62971DAE-CE71-4E9C-B6F5-514C8E2B915C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LINGYUN.Abp.Notifications.Jobs", "modules\common\LINGYUN.Abp.Notifications.Jobs\LINGYUN.Abp.Notifications.Jobs.csproj", "{3E9D07D8-963C-4A61-B720-BD47593BE752}"
 EndProject

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/AbpNotificationTemplateDefinitionProvider.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/AbpNotificationTemplateDefinitionProvider.cs
@@ -14,8 +14,10 @@ public class AbpNotificationTemplateDefinitionProvider : TemplateDefinitionProvi
 
     public override void Define(ITemplateDefinitionContext context)
     {
-        var notifications = _notificationDefinitionManager.GetAll().Where(n => n.Template != null);
-        foreach (var notification in notifications)
+        var notifications = _notificationDefinitionManager
+            .GetNotificationsAsync().GetAwaiter().GetResult();
+
+        foreach (var notification in notifications.Where(n => n.Template != null))
         {
             context.Add(notification.Template);
         }

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/IDynamicNotificationDefinitionStore.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/IDynamicNotificationDefinitionStore.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LINGYUN.Abp.Notifications;
+
+public interface IDynamicNotificationDefinitionStore
+{
+    Task<NotificationDefinition> GetOrNullAsync(string name);
+
+    Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync();
+
+    Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync();
+}

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/INotificationDefinitionManager.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/INotificationDefinitionManager.cs
@@ -1,17 +1,18 @@
 ﻿using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LINGYUN.Abp.Notifications
 {
     public interface INotificationDefinitionManager
     {
         [NotNull]
-        NotificationDefinition Get([NotNull] string name);
+        Task<NotificationDefinition> GetAsync([NotNull] string name);
 
-        IReadOnlyList<NotificationDefinition> GetAll();
+        Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync();
 
-        NotificationDefinition GetOrNull(string name);
+        Task<NotificationDefinition> GetOrNullAsync(string name);
 
-        IReadOnlyList<NotificationGroupDefinition> GetGroups();
+        Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync();
     }
 }

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/IStaticNotificationDefinitionStore.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/IStaticNotificationDefinitionStore.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LINGYUN.Abp.Notifications;
+
+public interface IStaticNotificationDefinitionStore
+{
+    Task<NotificationDefinition> GetOrNullAsync(string name);
+
+    Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync();
+
+    Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync();
+}

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NotificationDefinition.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NotificationDefinition.cs
@@ -83,7 +83,7 @@ namespace LINGYUN.Abp.Notifications
         {
             if (!providers.IsNullOrEmpty())
             {
-                Providers.AddRange(providers);
+                Providers.AddIfNotContains(providers);
             }
 
             return this;

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NotificationGroupDefinition.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NotificationGroupDefinition.cs
@@ -32,6 +32,14 @@ namespace LINGYUN.Abp.Notifications
         public IReadOnlyList<NotificationDefinition> Notifications => _notifications.ToImmutableList();
         private readonly List<NotificationDefinition> _notifications;
 
+        public static NotificationGroupDefinition Create(
+            string name,
+            ILocalizableString displayName = null,
+            bool allowSubscriptionToClients = false)
+        {
+            return new NotificationGroupDefinition(name, displayName, allowSubscriptionToClients);
+        }
+
         protected internal NotificationGroupDefinition(
             string name,
             ILocalizableString displayName = null,

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NullDynamicNotificationDefinitionStore.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/NullDynamicNotificationDefinitionStore.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Volo.Abp.DependencyInjection;
+
+namespace LINGYUN.Abp.Notifications;
+
+[Dependency(TryRegister = true)]
+public class NullDynamicNotificationDefinitionStore : IDynamicNotificationDefinitionStore, ISingletonDependency
+{
+    private readonly static Task<NotificationDefinition> CachedNotificationResult = Task.FromResult((NotificationDefinition)null);
+
+    private readonly static Task<IReadOnlyList<NotificationDefinition>> CachedNotificationsResult =
+        Task.FromResult((IReadOnlyList<NotificationDefinition>)Array.Empty<NotificationDefinition>().ToImmutableList());
+
+    private readonly static Task<IReadOnlyList<NotificationGroupDefinition>> CachedGroupsResult =
+        Task.FromResult((IReadOnlyList<NotificationGroupDefinition>)Array.Empty<NotificationGroupDefinition>().ToImmutableList());
+
+    public Task<NotificationDefinition> GetOrNullAsync(string name)
+    {
+        return CachedNotificationResult;
+    }
+
+    public Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync()
+    {
+        return CachedNotificationsResult;
+    }
+
+    public Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync()
+    {
+        return CachedGroupsResult;
+    }
+}

--- a/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/StaticNotificationDefinitionStore.cs
+++ b/aspnet-core/modules/common/LINGYUN.Abp.Notifications.Core/LINGYUN/Abp/Notifications/StaticNotificationDefinitionStore.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+
+namespace LINGYUN.Abp.Notifications;
+
+public class StaticNotificationDefinitionStore : IStaticNotificationDefinitionStore, ISingletonDependency
+{
+    protected IDictionary<string, NotificationGroupDefinition> NotificationGroupDefinitions => _lazyNotificationGroupDefinitions.Value;
+    private readonly Lazy<Dictionary<string, NotificationGroupDefinition>> _lazyNotificationGroupDefinitions;
+
+    protected IDictionary<string, NotificationDefinition> NotificationDefinitions => _lazyNotificationDefinitions.Value;
+    private readonly Lazy<Dictionary<string, NotificationDefinition>> _lazyNotificationDefinitions;
+
+    protected AbpNotificationsOptions Options { get; }
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    public StaticNotificationDefinitionStore(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptions<AbpNotificationsOptions> options)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        Options = options.Value;
+
+        _lazyNotificationDefinitions = new Lazy<Dictionary<string, NotificationDefinition>>(
+            CreateNotificationDefinitions,
+            isThreadSafe: true
+        );
+
+        _lazyNotificationGroupDefinitions = new Lazy<Dictionary<string, NotificationGroupDefinition>>(
+            CreateNotificationGroupDefinitions,
+            isThreadSafe: true
+        );
+    }
+
+    protected virtual Dictionary<string, NotificationDefinition> CreateNotificationDefinitions()
+    {
+        var notifications = new Dictionary<string, NotificationDefinition>();
+
+        foreach (var groupDefinition in NotificationGroupDefinitions.Values)
+        {
+            foreach (var notification in groupDefinition.Notifications)
+            {
+                if (notifications.ContainsKey(notification.Name))
+                {
+                    throw new AbpException("Duplicate notification name: " + notification.Name);
+                }
+
+                notifications[notification.Name] = notification;
+            }
+        }
+
+        return notifications;
+    }
+
+    protected virtual Dictionary<string, NotificationGroupDefinition> CreateNotificationGroupDefinitions()
+    {
+        var context = new NotificationDefinitionContext();
+
+        using (var scope = _serviceScopeFactory.CreateScope())
+        {
+            var providers = Options
+                .DefinitionProviders
+                .Select(p => scope.ServiceProvider.GetRequiredService(p) as INotificationDefinitionProvider)
+                .ToList();
+
+            foreach (var provider in providers)
+            {
+                provider.Define(context);
+            }
+        }
+
+        return context.Groups;
+    }
+
+    public Task<NotificationDefinition> GetOrNullAsync(string name)
+    {
+        return Task.FromResult(NotificationDefinitions.GetOrDefault(name));
+    }
+
+    public virtual Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync()
+    {
+        return Task.FromResult<IReadOnlyList<NotificationDefinition>>(
+            NotificationDefinitions.Values.ToImmutableList()
+        );
+    }
+
+    public Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync()
+    {
+        return Task.FromResult<IReadOnlyList<NotificationGroupDefinition>>(
+            NotificationGroupDefinitions.Values.ToImmutableList()
+        );
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application.Contracts/LINGYUN/Abp/MessageService/Notifications/IMyNotificationAppService.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application.Contracts/LINGYUN/Abp/MessageService/Notifications/IMyNotificationAppService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 
 namespace LINGYUN.Abp.MessageService.Notifications
@@ -14,7 +13,5 @@ namespace LINGYUN.Abp.MessageService.Notifications
         IDeleteAppService<long>
     {
         Task MarkReadStateAsync(NotificationMarkReadStateInput input);
-
-        Task<ListResultDto<NotificationGroupDto>> GetAssignableNotifiersAsync();
     }
 }

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application.Contracts/LINGYUN/Abp/MessageService/Notifications/INotificationAppService.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application.Contracts/LINGYUN/Abp/MessageService/Notifications/INotificationAppService.cs
@@ -5,6 +5,8 @@ namespace LINGYUN.Abp.MessageService.Notifications
 {
     public interface INotificationAppService
     {
+        Task<ListResultDto<NotificationGroupDto>> GetAssignableNotifiersAsync();
+
         Task<ListResultDto<NotificationTemplateDto>> GetAssignableTemplatesAsync();
 
         Task SendAsync(NotificationSendDto input);

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application/LINGYUN/Abp/MessageService/Notifications/MyNotificationAppService.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Application/LINGYUN/Abp/MessageService/Notifications/MyNotificationAppService.cs
@@ -49,48 +49,6 @@ namespace LINGYUN.Abp.MessageService.Notifications
                     id);
         }
 
-        public virtual Task<ListResultDto<NotificationGroupDto>> GetAssignableNotifiersAsync()
-        {
-            var groups = new List<NotificationGroupDto>();
-
-            foreach (var group in NotificationDefinitionManager.GetGroups())
-            {
-                if (!group.AllowSubscriptionToClients)
-                {
-                    continue;
-
-                }
-                var notificationGroup = new NotificationGroupDto
-                {
-                    Name = group.Name,
-                    DisplayName = group.DisplayName.Localize(StringLocalizerFactory)
-                };
-
-                foreach (var notification in group.Notifications)
-                {
-                    if (!notification.AllowSubscriptionToClients)
-                    {
-                        continue;
-                    }
-
-                    var notificationChildren = new NotificationDto
-                    {
-                        Name = notification.Name,
-                        DisplayName = notification.DisplayName.Localize(StringLocalizerFactory),
-                        Description = notification.Description.Localize(StringLocalizerFactory),
-                        Lifetime = notification.NotificationLifetime,
-                        Type = notification.NotificationType
-                    };
-
-                    notificationGroup.Notifications.Add(notificationChildren);
-                }
-
-                groups.Add(notificationGroup);
-            }
-
-            return Task.FromResult(new ListResultDto<NotificationGroupDto>(groups));
-        }
-
         public async virtual Task<UserNotificationDto> GetAsync(long id)
         {
             var notification = await UserNotificationRepository.GetByIdAsync(CurrentUser.GetId(), id);

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain.Shared/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupRecordConsts.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain.Shared/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupRecordConsts.cs
@@ -1,0 +1,10 @@
+﻿namespace LINGYUN.Abp.MessageService.Notifications;
+
+public static class NotificationDefinitionGroupRecordConsts
+{
+    public static int MaxNameLength { get; set; } = 64;
+    public static int MaxDisplayNameLength { get; set; } = 255;
+    public static int MaxResourceNameLength { get; set; } = 64;
+    public static int MaxLocalizationLength { get; set; } = 128;
+    public static int MaxDescriptionLength { get; set; } = 255;
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain.Shared/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionRecordConsts.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain.Shared/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionRecordConsts.cs
@@ -1,0 +1,11 @@
+﻿namespace LINGYUN.Abp.MessageService.Notifications;
+
+public static class NotificationDefinitionRecordConsts
+{
+    public static int MaxNameLength { get; set; } = 64;
+    public static int MaxDisplayNameLength { get; set; } = 255;
+    public static int MaxResourceNameLength { get; set; } = 64;
+    public static int MaxLocalizationLength { get; set; } = 128;
+    public static int MaxDescriptionLength { get; set; } = 255;
+    public static int MaxProvidersLength { get; set; } = 200;
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/AbpNotificationsManagementOptions.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/AbpNotificationsManagementOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class AbpNotificationsManagementOptions
+{
+    public bool IsDynamicNotificationStoreEnabled { get; set; }
+    public AbpNotificationsManagementOptions()
+    {
+        IsDynamicNotificationStoreEnabled = true;
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/DynamicNotificationDefinitionCache.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/DynamicNotificationDefinitionCache.cs
@@ -1,0 +1,287 @@
+﻿using LINGYUN.Abp.Notifications;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Volo.Abp.Caching;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
+using Volo.Abp.Threading;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class DynamicNotificationDefinitionCache : IDynamicNotificationDefinitionCache, ISingletonDependency
+{
+    private readonly static ConcurrentDictionary<string, NotificationDefinitionGroupsCacheItem> _dynamicNotificationGroupL1Cache;
+    private readonly static ConcurrentDictionary<string, NotificationDefinitionsCacheItem> _dynamicNotificationsL1Cache;
+
+    private readonly static SemaphoreSlim _l2CacheSyncLock;
+    protected IMemoryCache DynamicNotificationL2Cache { get; }
+
+    protected IDistributedCache<NotificationDefinitionGroupsCacheItem> DynamicNotificationGroupL3Cache { get; }
+    protected IDistributedCache<NotificationDefinitionsCacheItem> DynamicNotificationsL3Cache { get; }
+
+
+    protected INotificationDefinitionGroupRecordRepository NotificationDefinitionGroupRecordRepository { get; }
+    protected INotificationDefinitionRecordRepository NotificationDefinitionRecordRepository { get; }
+
+    protected AbpLocalizationOptions LocalizationOptions { get; }
+    protected IStringLocalizerFactory StringLocalizerFactory { get; }
+
+    static DynamicNotificationDefinitionCache()
+    {
+        _l2CacheSyncLock = new SemaphoreSlim(1, 1);
+        _dynamicNotificationsL1Cache = new ConcurrentDictionary<string, NotificationDefinitionsCacheItem>();
+        _dynamicNotificationGroupL1Cache = new ConcurrentDictionary<string, NotificationDefinitionGroupsCacheItem>();
+    }
+
+    public DynamicNotificationDefinitionCache(
+        IMemoryCache dynamicNotificationL2Cache, 
+        IDistributedCache<NotificationDefinitionGroupsCacheItem> dynamicNotificationGroupL3Cache,
+        IDistributedCache<NotificationDefinitionsCacheItem> dynamicNotificationsL3Cache, 
+        INotificationDefinitionGroupRecordRepository notificationDefinitionGroupRecordRepository, 
+        INotificationDefinitionRecordRepository notificationDefinitionRecordRepository, 
+        IOptions<AbpLocalizationOptions> localizationOptions, 
+        IStringLocalizerFactory stringLocalizerFactory)
+    {
+        DynamicNotificationL2Cache = dynamicNotificationL2Cache;
+        DynamicNotificationGroupL3Cache = dynamicNotificationGroupL3Cache;
+        DynamicNotificationsL3Cache = dynamicNotificationsL3Cache;
+        NotificationDefinitionGroupRecordRepository = notificationDefinitionGroupRecordRepository;
+        NotificationDefinitionRecordRepository = notificationDefinitionRecordRepository;
+        LocalizationOptions = localizationOptions.Value;
+        StringLocalizerFactory = stringLocalizerFactory;
+    }
+
+    public async virtual Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync()
+    {
+        var cacheKey = NotificationDefinitionGroupsCacheItem.CalculateCacheKey(CultureInfo.CurrentCulture.Name);
+
+        if (!_dynamicNotificationGroupL1Cache.TryGetValue(cacheKey, out var cacheItem))
+        {
+            cacheItem = await GetGroupsFormL2CacheAsync(cacheKey);
+        }
+
+        return cacheItem.Groups
+            .Select(g => NotificationGroupDefinition
+                .Create(g.Name, new FixedLocalizableString(g.DisplayName), g.AllowSubscriptionToClients))
+            .ToImmutableList();
+    }
+
+    public async virtual Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync()
+    {
+        var cacheKey = NotificationDefinitionsCacheItem.CalculateCacheKey(CultureInfo.CurrentCulture.Name);
+
+        if (!_dynamicNotificationsL1Cache.TryGetValue(cacheKey, out var cacheItem))
+        {
+            cacheItem = await GetNotificationsFormL2CacheAsync(cacheKey);
+        }
+
+        return cacheItem.Notifications
+            .Select(n => new NotificationDefinition(
+                n.Name, 
+                new FixedLocalizableString(n.DisplayName), 
+                new FixedLocalizableString(n.Description),
+                n.NotificationType,
+                n.Lifetime,
+                n.AllowSubscriptionToClients))
+            .ToImmutableList();
+    }
+
+    public async virtual Task<NotificationDefinition> GetOrNullAsync(string name)
+    {
+        var notifications = await GetNotificationsAsync();
+
+        return notifications.FirstOrDefault(n => n.Name.Equals(name));
+    }
+
+    protected async virtual Task<NotificationDefinitionGroupsCacheItem> GetGroupsFormL2CacheAsync(string cacheKey)
+    {
+        var cacheItem = DynamicNotificationL2Cache.Get<NotificationDefinitionGroupsCacheItem>(cacheKey);
+
+        if (cacheItem == null)
+        {
+            using (await _l2CacheSyncLock.LockAsync())
+            {
+                var l2cache = await GetGroupsFormL3CacheAsync(cacheKey);
+
+                var options = new MemoryCacheEntryOptions();
+                options.SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+                options.SetPriority(CacheItemPriority.High);
+                options.RegisterPostEvictionCallback((key, value, reason, state) =>
+                {
+                    _dynamicNotificationGroupL1Cache.Clear();
+                });
+
+                DynamicNotificationL2Cache.Set(cacheKey, l2cache, options);
+
+                return l2cache;
+            }
+        }
+
+        return cacheItem;
+    }
+
+    protected async virtual Task<NotificationDefinitionGroupsCacheItem> GetGroupsFormL3CacheAsync(string cacheKey)
+    {
+        var cacheItem = await DynamicNotificationGroupL3Cache.GetAsync(cacheKey);
+
+        if (cacheItem == null)
+        {
+            var records = await GetGroupsFormRepositoryAsync();
+            var recordCaches = new List<NotificationDefinitionGroupCacheItem>();
+
+            foreach (var record in records)
+            {
+                var displayName = record.DisplayName;
+                var description = record.Description;
+
+                if (!record.ResourceName.IsNullOrWhiteSpace() && !record.Localization.IsNullOrWhiteSpace())
+                {
+                    var resource = GetResourceOrNull(record.ResourceName);
+                    if (resource != null)
+                    {
+                        var localizer = StringLocalizerFactory.Create(resource.ResourceType);
+
+                        displayName = localizer[$"DisplayName:{record.Localization}"];
+                        description = localizer[$"Description:{record.Localization}"];
+                    }
+                }
+
+                recordCaches.Add(new NotificationDefinitionGroupCacheItem(
+                    record.Name,
+                    displayName,
+                    description,
+                    record.AllowSubscriptionToClients));
+            }
+
+            cacheItem = new NotificationDefinitionGroupsCacheItem(recordCaches.ToArray());
+
+            await DynamicNotificationGroupL3Cache.SetAsync(
+                cacheKey,
+                cacheItem,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(2),
+                    SlidingExpiration = TimeSpan.FromHours(1),
+                });
+        }
+
+        return cacheItem;
+    }
+
+    protected async virtual Task<List<NotificationDefinitionGroupRecord>> GetGroupsFormRepositoryAsync()
+    {
+        var records = await NotificationDefinitionGroupRecordRepository.GetListAsync();
+
+        return records;
+    }
+
+
+    protected async virtual Task<NotificationDefinitionsCacheItem> GetNotificationsFormL2CacheAsync(string cacheKey)
+    {
+        var cacheItem = DynamicNotificationL2Cache.Get<NotificationDefinitionsCacheItem>(cacheKey);
+
+        if (cacheItem == null)
+        {
+            using (await _l2CacheSyncLock.LockAsync())
+            {
+                var l2cache = await GetNotificationsFormL3CacheAsync(cacheKey);
+
+                var options = new MemoryCacheEntryOptions();
+                options.SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+                options.SetPriority(CacheItemPriority.High);
+                options.RegisterPostEvictionCallback((key, value, reason, state) =>
+                {
+                    _dynamicNotificationsL1Cache.Clear();
+                });
+
+                DynamicNotificationL2Cache.Set(cacheKey, l2cache, options);
+
+                return l2cache;
+            }
+        }
+
+        return cacheItem;
+    }
+
+    protected async virtual Task<NotificationDefinitionsCacheItem> GetNotificationsFormL3CacheAsync(string cacheKey)
+    {
+        var cacheItem = await DynamicNotificationsL3Cache.GetAsync(cacheKey);
+
+        if (cacheItem == null)
+        {
+            var records = await GetNotificationsFormRepositoryAsync();
+            var recordCaches = new List<NotificationDefinitionCacheItem>();
+
+            foreach (var record in records)
+            {
+                var displayName = record.Name;
+                var description = record.Name;
+                var providers = new List<string>();
+                if (!record.Providers.IsNullOrWhiteSpace())
+                {
+                    providers = record.Providers.Split(';').ToList();
+                }
+
+                if (record.ResourceName.IsNullOrWhiteSpace() && record.Localization.IsNullOrWhiteSpace())
+                {
+                    var resource = GetResourceOrNull(record.ResourceName);
+                    if (resource != null)
+                    {
+                        var localizer = StringLocalizerFactory.Create(resource.ResourceType);
+
+                        displayName = localizer[$"DisplayName:{record.Localization}"];
+                        description = localizer[$"Description:{record.Localization}"];
+                    }
+                }
+
+                var recordCache = new NotificationDefinitionCacheItem(
+                    record.Name,
+                    displayName,
+                    description,
+                    record.NotificationLifetime,
+                    record.NotificationType,
+                    providers,
+                    record.AllowSubscriptionToClients);
+                recordCache.Properties.AddIfNotContains(record.ExtraProperties);
+
+                recordCaches.Add(recordCache);
+            }
+
+            cacheItem = new NotificationDefinitionsCacheItem(recordCaches.ToArray());
+
+            await DynamicNotificationsL3Cache.SetAsync(
+                cacheKey,
+                cacheItem,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(2),
+                    SlidingExpiration = TimeSpan.FromHours(1),
+                });
+        }
+
+        return cacheItem;
+    }
+
+    protected async virtual Task<List<NotificationDefinitionRecord>> GetNotificationsFormRepositoryAsync()
+    {
+        var records = await NotificationDefinitionRecordRepository.GetListAsync();
+
+        return records;
+    }
+
+    protected virtual LocalizationResource GetResourceOrNull(string resourceName)
+    {
+        return LocalizationOptions.Resources.Values
+            .FirstOrDefault(x => x.ResourceName.Equals(resourceName));
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/DynamicNotificationDefinitionStore.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/DynamicNotificationDefinitionStore.cs
@@ -1,0 +1,50 @@
+﻿using LINGYUN.Abp.Notifications;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Volo.Abp.DependencyInjection;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+[Dependency(ReplaceServices = true)]
+public class DynamicNotificationDefinitionStore : IDynamicNotificationDefinitionStore, ITransientDependency
+{
+    private readonly AbpNotificationsManagementOptions _notificationsManagementOptions;
+    private readonly IDynamicNotificationDefinitionCache _dynamicNotificationDefinitionCache;
+
+    public DynamicNotificationDefinitionStore(
+        IDynamicNotificationDefinitionCache dynamicNotificationDefinitionCache,
+        IOptions<AbpNotificationsManagementOptions> notificationsManagementOptions)
+    {
+        _dynamicNotificationDefinitionCache = dynamicNotificationDefinitionCache;
+        _notificationsManagementOptions = notificationsManagementOptions.Value;
+    }
+
+    public async virtual Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync()
+    {
+        if (!_notificationsManagementOptions.IsDynamicNotificationStoreEnabled)
+        {
+            return Array.Empty<NotificationGroupDefinition>();
+        }
+        return await _dynamicNotificationDefinitionCache.GetGroupsAsync();
+    }
+
+    public async virtual Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync()
+    {
+        if (!_notificationsManagementOptions.IsDynamicNotificationStoreEnabled)
+        {
+            return Array.Empty<NotificationDefinition>();
+        }
+        return await _dynamicNotificationDefinitionCache.GetNotificationsAsync();
+    }
+
+    public async virtual Task<NotificationDefinition> GetOrNullAsync(string name)
+    {
+        if (!_notificationsManagementOptions.IsDynamicNotificationStoreEnabled)
+        {
+            return null;
+        }
+        return await _dynamicNotificationDefinitionCache.GetOrNullAsync(name);
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/IDynamicNotificationDefinitionCache.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/IDynamicNotificationDefinitionCache.cs
@@ -1,0 +1,14 @@
+﻿using LINGYUN.Abp.Notifications;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public interface IDynamicNotificationDefinitionCache
+{
+    Task<NotificationDefinition> GetOrNullAsync(string name);
+
+    Task<IReadOnlyList<NotificationDefinition>> GetNotificationsAsync();
+
+    Task<IReadOnlyList<NotificationGroupDefinition>> GetGroupsAsync();
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/INotificationDefinitionGroupRecordRepository.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/INotificationDefinitionGroupRecordRepository.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using Volo.Abp.Domain.Repositories;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public interface INotificationDefinitionGroupRecordRepository : IBasicRepository<NotificationDefinitionGroupRecord, Guid>
+{
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/INotificationDefinitionRecordRepository.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/INotificationDefinitionRecordRepository.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using Volo.Abp.Domain.Repositories;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public interface INotificationDefinitionRecordRepository : IBasicRepository<NotificationDefinitionRecord, Guid>
+{
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupRecord.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupRecord.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Entities;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class NotificationDefinitionGroupRecord : BasicAggregateRoot<Guid>, IHasExtraProperties
+{
+    /// <summary>
+    /// 分组名称
+    /// </summary>
+    public virtual string Name { get; set; }
+    /// <summary>
+    /// 显示名称
+    /// </summary>
+    /// <remarks>
+    /// 如果为空,回退到Name
+    /// </remarks>
+    public virtual string DisplayName { get; set; }
+    /// <summary>
+    /// 描述
+    /// </summary>
+    /// <remarks>
+    /// 如果为空,回退到Name
+    /// </remarks>
+    public virtual string Description { get; set; }
+    /// <summary>
+    /// 资源名称
+    /// </summary>
+    /// <remarks>
+    /// 如果不为空,作为参与本地化资源的名称
+    /// DisplayName = L["DisplayName:Localization"]
+    /// Description = L["Description:Localization"]
+    /// </remarks>
+    public virtual string ResourceName { get; protected set; }
+    /// <summary>
+    /// 本地化键值名称
+    /// </summary>
+    /// <remarks>
+    /// 如果不为空,作为参与本地化键值的名称
+    /// DisplayName = L["DisplayName:Localization"]
+    /// Description = L["Description:Localization"]
+    /// </remarks>
+    public virtual string Localization { get; protected set; }
+    /// <summary>
+    /// 允许客户端订阅
+    /// </summary>
+    public virtual bool AllowSubscriptionToClients { get; set; }
+
+    public ExtraPropertyDictionary ExtraProperties { get; protected set; }
+
+    public NotificationDefinitionGroupRecord() 
+    {
+        ExtraProperties = new ExtraPropertyDictionary();
+        this.SetDefaultsForExtraProperties();
+    }
+
+    public NotificationDefinitionGroupRecord(
+        Guid id,
+        string name,
+        string displayName = null,
+        string description = null,
+        string resourceName = null,
+        string localization = null)
+        : base(id)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(name), NotificationDefinitionGroupRecordConsts.MaxNameLength);
+        DisplayName = Check.Length(displayName, nameof(displayName), NotificationDefinitionGroupRecordConsts.MaxDisplayNameLength);
+        Description = Check.Length(description, nameof(description), NotificationDefinitionGroupRecordConsts.MaxDescriptionLength);
+
+        SetLocalization(resourceName, localization);
+
+        ExtraProperties = new ExtraPropertyDictionary();
+        this.SetDefaultsForExtraProperties();
+
+        AllowSubscriptionToClients = true;
+    }
+    /// <summary>
+    /// 设置本地化资源
+    /// </summary>
+    /// <param name="resourceName"></param>
+    /// <param name="localization"></param>
+    public void SetLocalization(string resourceName, string localization)
+    {
+        ResourceName = Check.Length(resourceName, nameof(resourceName), NotificationDefinitionGroupRecordConsts.MaxResourceNameLength);
+        Localization = Check.Length(localization, nameof(localization), NotificationDefinitionGroupRecordConsts.MaxLocalizationLength);
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupsCacheItem.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionGroupsCacheItem.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Volo.Abp.MultiTenancy;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+[Serializable]
+[IgnoreMultiTenancy]
+public class NotificationDefinitionGroupsCacheItem
+{
+    private const string CacheKeyFormat = "n:Abp_Notifications_Groups;c:{0}";
+
+    public NotificationDefinitionGroupCacheItem[] Groups { get; set; }
+
+    public NotificationDefinitionGroupsCacheItem()
+    {
+        Groups = new NotificationDefinitionGroupCacheItem[0];
+    }
+
+    public NotificationDefinitionGroupsCacheItem(
+        NotificationDefinitionGroupCacheItem[] groups)
+    {
+        Groups = groups;
+    }
+
+    public static string CalculateCacheKey(string culture)
+    {
+        return string.Format(CacheKeyFormat, culture);
+    }
+}
+
+public class NotificationDefinitionGroupCacheItem
+{
+    public string Name { get; set; }
+    public string DisplayName { get; set; }
+    public string Description { get; set; }
+    public bool AllowSubscriptionToClients { get; set; }
+    public NotificationDefinitionGroupCacheItem()
+    {
+
+    }
+
+    public NotificationDefinitionGroupCacheItem(
+        string name, 
+        string displayName = null, 
+        string description = null,
+        bool allowSubscriptionToClients  = false)
+    {
+        Name = name;
+        DisplayName = displayName;
+        Description = description;
+        AllowSubscriptionToClients = allowSubscriptionToClients;
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionRecord.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionRecord.cs
@@ -1,0 +1,127 @@
+﻿using LINGYUN.Abp.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Entities;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class NotificationDefinitionRecord : BasicAggregateRoot<Guid>, IHasExtraProperties
+{
+    /// <summary>
+    /// 名称
+    /// </summary>
+    public virtual string Name { get; set; }
+    /// <summary>
+    /// 显示名称
+    /// </summary>
+    /// <remarks>
+    /// 如果为空,回退到Name
+    /// </remarks>
+    public virtual string DisplayName { get; set; }
+    /// <summary>
+    /// 描述
+    /// </summary>
+    /// <remarks>
+    /// 如果为空,回退到Name
+    /// </remarks>
+    public virtual string Description { get; set; }
+    /// <summary>
+    /// 资源名称
+    /// </summary>
+    /// <remarks>
+    /// 如果不为空,作为参与本地化资源的名称
+    /// DisplayName = L["DisplayName:Localization"]
+    /// Description = L["Description:Localization"]
+    /// </remarks>
+    public virtual string ResourceName { get; protected set; }
+    /// <summary>
+    /// 本地化键值名称
+    /// </summary>
+    /// <remarks>
+    /// 如果不为空,作为参与本地化键值的名称
+    /// DisplayName = L["DisplayName:Localization"]
+    /// Description = L["Description:Localization"]
+    /// </remarks>
+    public virtual string Localization { get; protected set; }
+    /// <summary>
+    /// 存活类型
+    /// </summary>
+    public virtual NotificationLifetime NotificationLifetime { get; set; }
+    /// <summary>
+    /// 通知类型
+    /// </summary>
+    public virtual NotificationType NotificationType { get; set; }
+    /// <summary>
+    /// 通知提供者
+    /// </summary>
+    /// <remarks>
+    /// 多个之间用;分隔
+    /// </remarks>
+    public virtual string Providers { get; protected set; }
+    /// <summary>
+    /// 允许客户端订阅
+    /// </summary>
+    public virtual bool AllowSubscriptionToClients { get; set; }
+    public ExtraPropertyDictionary ExtraProperties { get; protected set; }
+
+    public NotificationDefinitionRecord()
+    {
+        ExtraProperties = new ExtraPropertyDictionary();
+        this.SetDefaultsForExtraProperties();
+    }
+
+    public NotificationDefinitionRecord(
+        Guid id,
+        string name,
+        string displayName = null,
+        string description = null,
+        string resourceName = null,
+        string localization = null,
+        NotificationLifetime lifetime = NotificationLifetime.Persistent,
+        NotificationType notificationType = NotificationType.Application)
+        : base(id)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(name), NotificationDefinitionRecordConsts.MaxNameLength);
+        DisplayName = Check.Length(displayName, nameof(displayName), NotificationDefinitionRecordConsts.MaxDisplayNameLength);
+        Description = Check.Length(description, nameof(description), NotificationDefinitionRecordConsts.MaxDescriptionLength);
+        NotificationLifetime = lifetime;
+        NotificationType = notificationType;
+
+        SetLocalization(resourceName, localization);
+
+        ExtraProperties = new ExtraPropertyDictionary();
+        this.SetDefaultsForExtraProperties();
+
+        AllowSubscriptionToClients = true;
+    }
+    /// <summary>
+    /// 设置本地化资源
+    /// </summary>
+    /// <param name="resourceName"></param>
+    /// <param name="localization"></param>
+    public void SetLocalization(string resourceName, string localization)
+    {
+        ResourceName = Check.Length(resourceName, nameof(resourceName), NotificationDefinitionGroupRecordConsts.MaxResourceNameLength);
+        Localization = Check.Length(localization, nameof(localization), NotificationDefinitionGroupRecordConsts.MaxLocalizationLength);
+    }
+
+    public void UseProviders(params string[] providers)
+    {
+        var currentProviders = Providers.IsNullOrWhiteSpace()
+            ? new List<string>()
+            : Providers.Split(';').ToList();
+
+        if (!providers.IsNullOrEmpty())
+        {
+            currentProviders.AddIfNotContains(providers);
+        }
+
+        if (currentProviders.Any())
+        {
+            Providers = currentProviders.JoinAsString(";");
+        }
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionsCacheItem.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.Domain/LINGYUN/Abp/MessageService/Notifications/NotificationDefinitionsCacheItem.cs
@@ -1,0 +1,68 @@
+﻿using LINGYUN.Abp.Notifications;
+using System;
+using System.Collections.Generic;
+using Volo.Abp.MultiTenancy;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+[Serializable]
+[IgnoreMultiTenancy]
+public class NotificationDefinitionsCacheItem
+{
+    private const string CacheKeyFormat = "n:Abp_Notifications;c:{0}";
+
+    public NotificationDefinitionCacheItem[] Notifications { get; set; }
+
+    public NotificationDefinitionsCacheItem()
+    {
+        Notifications = new NotificationDefinitionCacheItem[0];
+    }
+
+    public NotificationDefinitionsCacheItem(
+        NotificationDefinitionCacheItem[] notifications)
+    {
+        Notifications = notifications;
+    }
+
+    public static string CalculateCacheKey(string culture)
+    {
+        return string.Format(CacheKeyFormat, culture);
+    }
+}
+
+public class NotificationDefinitionCacheItem
+{
+    public string Name { get; set; }
+    public string DisplayName { get; set; }
+    public string Description { get; set; }
+    public NotificationLifetime Lifetime { get; set; }
+    public NotificationType NotificationType { get; set; }
+    public List<string> Providers { get; set; }
+    public bool AllowSubscriptionToClients { get; set; }
+    public Dictionary<string, object> Properties { get; set; }
+    public NotificationDefinitionCacheItem()
+    {
+        Providers = new List<string>();
+        Properties = new Dictionary<string, object>();
+    }
+
+    public NotificationDefinitionCacheItem(
+        string name, 
+        string displayName = null, 
+        string description = null,
+        NotificationLifetime lifetime = NotificationLifetime.Persistent,
+        NotificationType notificationType = NotificationType.Application,
+        List<string> providers = null,
+        bool allowSubscriptionToClients  = false)
+    {
+        Name = name;
+        DisplayName = displayName;
+        Description = description;
+        Lifetime = lifetime;
+        NotificationType = notificationType;
+        Providers = providers ?? new List<string>();
+        AllowSubscriptionToClients = allowSubscriptionToClients;
+
+        Properties = new Dictionary<string, object>();
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/EntityFrameworkCore/AbpMessageServiceEntityFrameworkCoreModule.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/EntityFrameworkCore/AbpMessageServiceEntityFrameworkCoreModule.cs
@@ -18,6 +18,8 @@ namespace LINGYUN.Abp.MessageService.EntityFrameworkCore
             context.Services.AddAbpDbContext<MessageServiceDbContext>(options =>
             {
                 options.AddRepository<Notification, EfCoreNotificationRepository>();
+                options.AddRepository<NotificationDefinitionRecord, EfCoreNotificationDefinitionRecordRepository>();
+                options.AddRepository<NotificationDefinitionGroupRecord, EfCoreNotificationDefinitionGroupRecordRepository>();
 
                 options.AddRepository<UserNotification, EfCoreUserNotificationRepository>();
                 options.AddRepository<UserSubscribe, EfCoreUserSubscribeRepository>();

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/EntityFrameworkCore/MessageServiceDbContextModelCreatingExtensions.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/EntityFrameworkCore/MessageServiceDbContextModelCreatingExtensions.cs
@@ -186,6 +186,48 @@ namespace LINGYUN.Abp.MessageService.EntityFrameworkCore
 
                 b.HasIndex(p => new { p.TenantId, p.GroupId, p.UserId });
             });
+
+            builder.Entity<NotificationDefinitionGroupRecord>(b =>
+            {
+                b.ToTable(options.TablePrefix + "NotificationDefinitionGroups", options.Schema);
+
+                b.Property(p => p.Name)
+                 .HasMaxLength(NotificationDefinitionGroupRecordConsts.MaxNameLength)
+                 .IsRequired();
+
+                b.Property(p => p.DisplayName)
+                 .HasMaxLength(NotificationDefinitionGroupRecordConsts.MaxDisplayNameLength);
+                b.Property(p => p.Description)
+                 .HasMaxLength(NotificationDefinitionGroupRecordConsts.MaxDescriptionLength);
+                b.Property(p => p.ResourceName)
+                 .HasMaxLength(NotificationDefinitionGroupRecordConsts.MaxResourceNameLength);
+                b.Property(p => p.Localization)
+                 .HasMaxLength(NotificationDefinitionGroupRecordConsts.MaxLocalizationLength);
+
+                b.ConfigureByConvention();
+            });
+
+            builder.Entity<NotificationDefinitionRecord>(b =>
+            {
+                b.ToTable(options.TablePrefix + "NotificationDefinitions", options.Schema);
+
+                b.Property(p => p.Name)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxNameLength)
+                 .IsRequired();
+
+                b.Property(p => p.DisplayName)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxDisplayNameLength);
+                b.Property(p => p.Description)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxDescriptionLength);
+                b.Property(p => p.ResourceName)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxResourceNameLength);
+                b.Property(p => p.Localization)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxLocalizationLength);
+                b.Property(p => p.Providers)
+                 .HasMaxLength(NotificationDefinitionRecordConsts.MaxProvidersLength);
+
+                b.ConfigureByConvention();
+            });
         }
     }
 }

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/Notifications/EfCoreNotificationDefinitionGroupRecordRepository.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/Notifications/EfCoreNotificationDefinitionGroupRecordRepository.cs
@@ -1,0 +1,19 @@
+﻿using LINGYUN.Abp.MessageService.EntityFrameworkCore;
+using System;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class EfCoreNotificationDefinitionGroupRecordRepository :
+    EfCoreRepository<IMessageServiceDbContext, NotificationDefinitionGroupRecord, Guid>,
+    INotificationDefinitionGroupRecordRepository,
+    ITransientDependency
+{
+    public EfCoreNotificationDefinitionGroupRecordRepository(
+        IDbContextProvider<IMessageServiceDbContext> dbContextProvider) 
+        : base(dbContextProvider)
+    {
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/Notifications/EfCoreNotificationDefinitionRecordRepository.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.EntityFrameworkCore/LINGYUN/Abp/MessageService/Notifications/EfCoreNotificationDefinitionRecordRepository.cs
@@ -1,0 +1,19 @@
+﻿using LINGYUN.Abp.MessageService.EntityFrameworkCore;
+using System;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace LINGYUN.Abp.MessageService.Notifications;
+
+public class EfCoreNotificationDefinitionRecordRepository :
+    EfCoreRepository<IMessageServiceDbContext, NotificationDefinitionRecord, Guid>,
+    INotificationDefinitionRecordRepository,
+    ITransientDependency
+{
+    public EfCoreNotificationDefinitionRecordRepository(
+        IDbContextProvider<IMessageServiceDbContext> dbContextProvider)
+        : base(dbContextProvider)
+    {
+    }
+}

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.HttpApi/LINGYUN/Abp/MessageService/Notifications/MyNotificationController.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.HttpApi/LINGYUN/Abp/MessageService/Notifications/MyNotificationController.cs
@@ -31,13 +31,7 @@ namespace LINGYUN.Abp.MessageService.Notifications
         {
             await MyNotificationAppService.DeleteAsync(id);
         }
-
-        [HttpGet]
-        [Route("assignables")]
-        public async virtual Task<ListResultDto<NotificationGroupDto>> GetAssignableNotifiersAsync()
-        {
-            return await MyNotificationAppService.GetAssignableNotifiersAsync();
-        }
+        
 
         [HttpGet]
         [Route("{id}")]

--- a/aspnet-core/modules/message/LINGYUN.Abp.MessageService.HttpApi/LINGYUN/Abp/MessageService/Notifications/NotificationController.cs
+++ b/aspnet-core/modules/message/LINGYUN.Abp.MessageService.HttpApi/LINGYUN/Abp/MessageService/Notifications/NotificationController.cs
@@ -27,6 +27,13 @@ namespace LINGYUN.Abp.MessageService.Notifications
         }
 
         [HttpGet]
+        [Route("assignables")]
+        public async virtual Task<ListResultDto<NotificationGroupDto>> GetAssignableNotifiersAsync()
+        {
+            return await NotificationAppService.GetAssignableNotifiersAsync();
+        }
+
+        [HttpGet]
         [Route("assignable-templates")]
         public async virtual Task<ListResultDto<NotificationTemplateDto>> GetAssignableTemplatesAsync()
         {

--- a/aspnet-core/modules/pushplus/LINGYUN.Abp.Notifications.PushPlus/LINGYUN/Abp/Notifications/PushPlus/PushPlusNotificationPublishProvider.cs
+++ b/aspnet-core/modules/pushplus/LINGYUN.Abp.Notifications.PushPlus/LINGYUN/Abp/Notifications/PushPlus/PushPlusNotificationPublishProvider.cs
@@ -65,7 +65,7 @@ public class PushPlusNotificationPublishProvider : NotificationPublishProvider
     {
         var topic = "";
 
-        var notificationDefine = NotificationDefinitionManager.GetOrNull(notification.Name);
+        var notificationDefine = await NotificationDefinitionManager.GetOrNullAsync(notification.Name);
         var topicDefine = notificationDefine?.GetTopicOrNull();
         if (!topicDefine.IsNullOrWhiteSpace())
         {

--- a/aspnet-core/modules/wx-pusher/LINGYUN.Abp.Notifications.WxPusher/LINGYUN/Abp/Notifications/WxPusher/WxPusherNotificationPublishProvider.cs
+++ b/aspnet-core/modules/wx-pusher/LINGYUN.Abp.Notifications.WxPusher/LINGYUN/Abp/Notifications/WxPusher/WxPusherNotificationPublishProvider.cs
@@ -72,7 +72,7 @@ public class WxPusherNotificationPublishProvider : NotificationPublishProvider
         var topics = await WxPusherUserStore.GetSubscribeTopicsAsync(subscribeUserIds, cancellationToken);
         var uids = await WxPusherUserStore.GetBindUidsAsync(subscribeUserIds, cancellationToken);
 
-        var notificationDefine = NotificationDefinitionManager.GetOrNull(notification.Name);
+        var notificationDefine = await NotificationDefinitionManager.GetOrNullAsync(notification.Name);
         var url = notification.Data.GetUrlOrNull() ?? notificationDefine?.GetUrlOrNull();
         var topicDefine = notificationDefine?.GetTopics();
         if (topicDefine.Any())

--- a/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/EventBus/Distributed/NotificationEventHandler.cs
+++ b/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/EventBus/Distributed/NotificationEventHandler.cs
@@ -109,7 +109,7 @@ namespace LY.MicroService.RealtimeMessage.EventBus.Distributed
         {
             using (CurrentTenant.Change(eventData.TenantId))
             {
-                var notification = NotificationDefinitionManager.GetOrNull(eventData.Name);
+                var notification = await NotificationDefinitionManager.GetOrNullAsync(eventData.Name);
                 if (notification == null)
                 {
                     return;
@@ -177,8 +177,7 @@ namespace LY.MicroService.RealtimeMessage.EventBus.Distributed
         {
             using (CurrentTenant.Change(eventData.TenantId))
             {
-                // 如果上面过滤了应用程序,这里可以使用Get方法,否则,最好使用GetOrNull加以判断
-                var notification = NotificationDefinitionManager.GetOrNull(eventData.Name);
+                var notification = await NotificationDefinitionManager.GetOrNullAsync(eventData.Name);
                 if (notification == null)
                 {
                     return;

--- a/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/Migrations/20220902104049_Add-Dynamic-Notification.Designer.cs
+++ b/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/Migrations/20220902104049_Add-Dynamic-Notification.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LY.MicroService.RealtimeMessage.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -11,9 +12,10 @@ using Volo.Abp.EntityFrameworkCore;
 namespace LY.MicroService.RealtimeMessage.Migrations
 {
     [DbContext(typeof(RealtimeMessageMigrationsDbContext))]
-    partial class RealtimeMessageMigrationsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220902104049_Add-Dynamic-Notification")]
+    partial class AddDynamicNotification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/Migrations/20220902104049_Add-Dynamic-Notification.cs
+++ b/aspnet-core/services/LY.MicroService.RealtimeMessage.HttpApi.Host/Migrations/20220902104049_Add-Dynamic-Notification.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LY.MicroService.RealtimeMessage.Migrations
+{
+    public partial class AddDynamicNotification : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppNotificationDefinitionGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    Name = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    DisplayName = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ResourceName = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Localization = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    AllowSubscriptionToClients = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppNotificationDefinitionGroups", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "AppNotificationDefinitions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    Name = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    DisplayName = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ResourceName = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Localization = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    NotificationLifetime = table.Column<int>(type: "int", nullable: false),
+                    NotificationType = table.Column<int>(type: "int", nullable: false),
+                    Providers = table.Column<string>(type: "varchar(200)", maxLength: 200, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    AllowSubscriptionToClients = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppNotificationDefinitions", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppNotificationDefinitionGroups");
+
+            migrationBuilder.DropTable(
+                name: "AppNotificationDefinitions");
+        }
+    }
+}


### PR DESCRIPTION
* Change INotificationDefinitionManager to asynchronous  methods
* Increase IStaticNotificationDefinitionStore interface for users to define static notice
* Increase IDynamicNotificationDefinitionStore interface to get dynamic notification from other source definition
* Increase DynamicNotificationDefinitionStore get dynamic notification from l3 cache
* Add Entity NotificationDefinitionGroupRecord
* Add Repository INotificationDefinitionGroupRecordRepository
* Add Entity NotificationDefinitionRecord
* Add Repository INotificationDefinitionRecordRepository