### PR TITLE
Do not change cookies when downloading files

### DIFF
--- a/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.Application.Contracts/LINGYUN/Abp/OssManagement/GetPublicFileInput.cs
+++ b/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.Application.Contracts/LINGYUN/Abp/OssManagement/GetPublicFileInput.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace LINGYUN.Abp.OssManagement
 {
@@ -10,5 +11,9 @@ namespace LINGYUN.Abp.OssManagement
         public string Path { get; set; }
 
         public string Process { get; set; }
+        /// <summary>
+        /// 解决通过路由传递租户标识时,abp写入cookies
+        /// </summary>
+        public Guid? TenantId { get; set; }
     }
 }

--- a/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.Application.Contracts/LINGYUN/Abp/OssManagement/GetStaticFileInput.cs
+++ b/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.Application.Contracts/LINGYUN/Abp/OssManagement/GetStaticFileInput.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace LINGYUN.Abp.OssManagement
 {
@@ -12,5 +13,9 @@ namespace LINGYUN.Abp.OssManagement
         public string Bucket { get; set; }
 
         public string Process { get; set; }
+        /// <summary>
+        /// 解决通过路由传递租户标识时,abp写入cookies
+        /// </summary>
+        public Guid? TenantId { get; set; }
     }
 }

--- a/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/PrivateFilesController.cs
+++ b/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/PrivateFilesController.cs
@@ -51,9 +51,16 @@ namespace LINGYUN.Abp.OssManagement
         [Route("{Name}/{Process}")]
         [Route("p/{Path}/{Name}")]
         [Route("p/{Path}/{Name}/{Process}")]
+        [Route("t/{TenantId}/{Name}")]
+        [Route("t/{TenantId}/{Name}/{Process}")]
+        [Route("t/{TenantId}/p/{Path}/{Name}")]
+        [Route("t/{TenantId}/p/{Path}/{Name}/{Process}")]
         public async virtual Task<IRemoteStreamContent> GetAsync([FromRoute] GetPublicFileInput input)
         {
-            return await _service.GetAsync(input);
+            using (CurrentTenant.Change(input.TenantId ?? CurrentTenant.Id))
+            {
+                return await _service.GetAsync(input);
+            }
         }
 
         [HttpDelete]

--- a/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/PublicFilesController.cs
+++ b/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/PublicFilesController.cs
@@ -50,9 +50,16 @@ namespace LINGYUN.Abp.OssManagement
         [Route("{Name}/{Process}")]
         [Route("p/{Path}/{Name}")]
         [Route("p/{Path}/{Name}/{Process}")]
+        [Route("t/{TenantId}/{Name}")]
+        [Route("t/{TenantId}/{Name}/{Process}")]
+        [Route("t/{TenantId}/p/{Path}/{Name}")]
+        [Route("t/{TenantId}/p/{Path}/{Name}/{Process}")]
         public async virtual Task<IRemoteStreamContent> GetAsync([FromRoute] GetPublicFileInput input)
         {
-            return await _publicFileAppService.GetAsync(input);
+            using (CurrentTenant.Change(input.TenantId ?? CurrentTenant.Id))
+            {
+                return await _publicFileAppService.GetAsync(input);
+            }
         }
 
         [HttpDelete]

--- a/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/StaticFilesController.cs
+++ b/aspnet-core/modules/oss-management/LINGYUN.Abp.OssManagement.HttpApi/LINGYUN/Abp/OssManagement/StaticFilesController.cs
@@ -39,9 +39,16 @@ namespace LINGYUN.Abp.OssManagement
         [Route("{Bucket}/{Name}/{Process}")]
         [Route("{Bucket}/p/{Path}/{Name}")]
         [Route("{Bucket}/p/{Path}/{Name}/{Process}")]
+        [Route("t/{TenantId}/{Bucket}/{Name}")]
+        [Route("t/{TenantId}/{Bucket}/{Name}/{Process}")]
+        [Route("t/{TenantId}/{Bucket}/p/{Path}/{Name}")]
+        [Route("t/{TenantId}/{Bucket}/p/{Path}/{Name}/{Process}")]
         public async virtual Task<IRemoteStreamContent> GetAsync([FromRoute] GetStaticFileInput input)
         {
-            return await _staticFilesAppServic.GetAsync(input);
+            using (CurrentTenant.Change(input.TenantId ?? CurrentTenant.Id))
+            {
+                return await _staticFilesAppServic.GetAsync(input);
+            }
         }
     }
 }


### PR DESCRIPTION
外部访问oss时，需要通过路由或FormData传递租户标识，而UseMultiTenancy中间件可能会写入cookies对业务造成干扰，因此需要显示传递租户标识到路由中