### PR TITLE
fix volo abp package downgrade issue

### DIFF
--- a/gateways/Directory.Build.props
+++ b/gateways/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<VoloAbpPackageVersion>6.0.1</VoloAbpPackageVersion>
+		<VoloAbpPackageVersion>6.0.2</VoloAbpPackageVersion>
 		<LINGYUNAbpPackageVersion>6.0.1</LINGYUNAbpPackageVersion>
 		<DaprPackageVersion>1.8.0</DaprPackageVersion>
 		<DotNetCoreCAPPackageVersion>6.0.1</DotNetCoreCAPPackageVersion>


### PR DESCRIPTION
fix the error when building the ApiGateway:
error NU1605: Detected package downgrade: Volo.Abp.AspNetCore from 6.0.2 to 6.0.1. Reference the package directly from the project to select a different version.