### PR TITLE
Elasticsearch.Net.ElasticsearchClientException

### DIFF
--- a/aspnet-core/modules/elasticsearch/LINGYUN.Abp.Elasticsearch/LINGYUN/Abp/Elasticsearch/AbpElasticsearchOptions.cs
+++ b/aspnet-core/modules/elasticsearch/LINGYUN.Abp.Elasticsearch/LINGYUN/Abp/Elasticsearch/AbpElasticsearchOptions.cs
@@ -57,7 +57,7 @@ namespace LINGYUN.Abp.Elasticsearch
                 configuration.DefaultFieldNameInferrer((name) => name);
             }
 
-            if (UserName.IsNullOrWhiteSpace())
+            if (!UserName.IsNullOrWhiteSpace())
             {
                 configuration.BasicAuthentication(UserName, Password);
             }


### PR DESCRIPTION
Elasticsearch.Net.ElasticsearchClientException: Could not authenticate with the specified node. Try verifying your credentials or check your Shield configuration. Call: Status code 401
I have a look, it seems that the if in the configuration file is reversed, help to confirm whether it is the problem.
If yes, could you help me merge it into 7.2.1.1
