### PR TITLE
fix(openiddict): Fix the potential problems of the newly built client

### DIFF
--- a/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application.Contracts/LINGYUN/Abp/OpenIddict/AbpOpenIddictApplicationContractsModule.cs
+++ b/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application.Contracts/LINGYUN/Abp/OpenIddict/AbpOpenIddictApplicationContractsModule.cs
@@ -1,5 +1,6 @@
 ﻿using Volo.Abp.Authorization;
 using Volo.Abp.Localization;
+using Volo.Abp.Localization.ExceptionHandling;
 using Volo.Abp.Modularity;
 using Volo.Abp.OpenIddict;
 using Volo.Abp.OpenIddict.Localization;
@@ -24,6 +25,11 @@ public class AbpOpenIddictApplicationContractsModule : AbpModule
             options.Resources
                 .Get<AbpOpenIddictResource>()
                 .AddVirtualJson("/LINGYUN/Abp/OpenIddict/Localization/Resources");
+        });
+
+        Configure<AbpExceptionLocalizationOptions>(options =>
+        {
+            options.MapCodeNamespace(OpenIddictApplicationErrorCodes.Namespace, typeof(AbpOpenIddictResource));
         });
     }
 }

--- a/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application.Contracts/LINGYUN/Abp/OpenIddict/OpenIddictApplicationErrorCodes.cs
+++ b/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application.Contracts/LINGYUN/Abp/OpenIddict/OpenIddictApplicationErrorCodes.cs
@@ -2,7 +2,7 @@
 
 public static class OpenIddictApplicationErrorCodes
 {
-    private const string Namespace = "OpenIddict:";
+    public const string Namespace = "OpenIddict:";
 
     public static class Applications
     {

--- a/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application/LINGYUN/Abp/OpenIddict/Applications/OpenIddictApplicationAppService.cs
+++ b/aspnet-core/modules/openIddict/LINGYUN.Abp.OpenIddict.Application/LINGYUN/Abp/OpenIddict/Applications/OpenIddictApplicationAppService.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Data;
-using Volo.Abp.OpenIddict;
 using Volo.Abp.OpenIddict.Applications;
 
 namespace LINGYUN.Abp.OpenIddict.Applications;
@@ -14,17 +13,14 @@ namespace LINGYUN.Abp.OpenIddict.Applications;
 [Authorize(AbpOpenIddictPermissions.Applications.Default)]
 public class OpenIddictApplicationAppService : OpenIddictApplicationServiceBase, IOpenIddictApplicationAppService
 {
-    private readonly IAbpApplicationManager _applicationManager;
-    private readonly AbpOpenIddictIdentifierConverter _identifierConverter;
+    private readonly AbpApplicationManager _applicationManager;
     private readonly IOpenIddictApplicationRepository _applicationRepository;
 
     public OpenIddictApplicationAppService(
-        IAbpApplicationManager applicationManager,
-        AbpOpenIddictIdentifierConverter identifierConverter,
+        AbpApplicationManager applicationManager,
         IOpenIddictApplicationRepository applicationRepository)
     {
         _applicationManager = applicationManager;
-        _identifierConverter = identifierConverter;
         _applicationRepository = applicationRepository;
     }
 
@@ -47,7 +43,7 @@ public class OpenIddictApplicationAppService : OpenIddictApplicationServiceBase,
     [Authorize(AbpOpenIddictPermissions.Applications.Create)]
     public async virtual Task<OpenIddictApplicationDto> CreateAsync(OpenIddictApplicationCreateDto input)
     {
-        if (await _applicationManager.FindByClientIdAsync(input.ClientId) != null)
+        if (await _applicationRepository.FindByClientIdAsync(input.ClientId) != null)
         {
             throw new BusinessException(OpenIddictApplicationErrorCodes.Applications.ClientIdExisted)
                 .WithData(nameof(OpenIddictApplication.ClientId), input.ClientId);
@@ -100,7 +96,7 @@ public class OpenIddictApplicationAppService : OpenIddictApplicationServiceBase,
     [Authorize(AbpOpenIddictPermissions.Applications.Delete)]
     public async virtual Task DeleteAsync(Guid id)
     {
-        var application = await _applicationManager.FindByIdAsync(_identifierConverter.ToString(id));
-        await _applicationManager.DeleteAsync(application);
+        var application = await _applicationRepository.GetAsync(id);
+        await _applicationManager.DeleteAsync(application.ToModel());
     }
 }


### PR DESCRIPTION
- After the user attempts to log in with a non-existent client Id, an error will be reported when creating a client with the same name due to cache issues
- 用户通过不存在的客户端Id尝试登录时,因缓存问题,将造成同名客户端无法新建