### PR TITLE
feat(templates): Upgrade the microservice startup template to 9.2.0

### DIFF
--- a/aspnet-core/templates/micro/PackageName.CompanyName.ProjectName.csproj
+++ b/aspnet-core/templates/micro/PackageName.CompanyName.ProjectName.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework> <!-- 或其他适合的框架 -->
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LINGYUN.Abp.MicroService.Templates</PackageId>
-    <Version>9.1.1</Version>
+    <Version>9.2.0</Version>
     <Authors>colin.in@foxmail.com</Authors>
     <Description>Abp framework micro-service template</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/aspnet-core/templates/micro/content/Directory.Packages.props
+++ b/aspnet-core/templates/micro/content/Directory.Packages.props
@@ -1,17 +1,18 @@
 <Project>
 	<PropertyGroup>
-		<DotNetCoreCAPPackageVersion>8.3.2</DotNetCoreCAPPackageVersion>
-		<ElsaPackageVersion>2.14.1</ElsaPackageVersion>
-		<VoloAbpPackageVersion>9.1.1</VoloAbpPackageVersion>
-		<LINGYUNAbpPackageVersion>9.1.1</LINGYUNAbpPackageVersion>
-		<MicrosoftExtensionsPackageVersion>9.0.0.0</MicrosoftExtensionsPackageVersion>
-		<MicrosoftAspNetCorePackageVersion>9.0.0.0</MicrosoftAspNetCorePackageVersion>
-		<MicrosoftEntityFrameworkCorePackageVersion>9.0.0.0</MicrosoftEntityFrameworkCorePackageVersion>
+		<DotNetCoreCAPPackageVersion>8.3.5</DotNetCoreCAPPackageVersion>
+		<ElsaPackageVersion>2.15.1</ElsaPackageVersion>
+		<VoloAbpPackageVersion>9.2.0</VoloAbpPackageVersion>
+		<LINGYUNAbpPackageVersion>9.2.0</LINGYUNAbpPackageVersion>
+		<MicrosoftExtensionsPackageVersion>9.0.4</MicrosoftExtensionsPackageVersion>
+		<MicrosoftAspNetCorePackageVersion>9.0.4</MicrosoftAspNetCorePackageVersion>
+		<MicrosoftEntityFrameworkCorePackageVersion>9.0.4</MicrosoftEntityFrameworkCorePackageVersion>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 
 	<!-- LINGYUN Abp Framework -->
 	<ItemGroup>
+		<PackageVersion Include="LINGYUN.Abp.Claims.Mapping" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.AspNetCore.HttpOverrides" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.AspNetCore.Mvc.Localization" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.AspNetCore.Mvc.Wrapper" Version="$(LINGYUNAbpPackageVersion)" />
@@ -84,7 +85,6 @@
 		<PackageVersion Include="LINGYUN.Abp.Features.LimitValidation" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.RealTime" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.Wrapper" Version="$(LINGYUNAbpPackageVersion)" />
-		<PackageVersion Include="LINGYUN.Abp.Exporter.MiniExcel" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.FeatureManagement.Client" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.Localization.Persistence" Version="$(LINGYUNAbpPackageVersion)" />
 		<PackageVersion Include="LINGYUN.Abp.Logging.Serilog.Elasticsearch" Version="$(LINGYUNAbpPackageVersion)" />
@@ -243,7 +243,7 @@
 
 	<!-- Abp Framework -->
 	<ItemGroup>
-		<PackageVersion Include="Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite" Version="4.1.1" />
+		<PackageVersion Include="Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite" Version="4.2.0" />
 		<PackageVersion Include="Volo.Abp.Core" Version="$(VoloAbpPackageVersion)" />
 		<PackageVersion Include="Volo.Abp.Account.Application" Version="$(VoloAbpPackageVersion)" />
 		<PackageVersion Include="Volo.Abp.Account.Application.Contracts" Version="$(VoloAbpPackageVersion)" />
@@ -428,37 +428,37 @@
 
 	<!-- Serilog -->
 	<ItemGroup>
-		<PackageVersion Include="Serilog" Version="4.0.2" />
-		<PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
-		<PackageVersion Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+		<PackageVersion Include="Serilog" Version="4.2.0" />
+		<PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+		<PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageVersion Include="Serilog.Enrichers.Assembly" Version="2.0.0" />
-		<PackageVersion Include="Serilog.Enrichers.Process" Version="2.0.2" />
-		<PackageVersion Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-		<PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-		<PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
-		<PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.2" />
-		<PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
+		<PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
+		<PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+		<PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.1" />
+		<PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
+		<PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
 		<PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageVersion Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
-		<PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+		<PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
 	</ItemGroup>
 
 	<!-- Test -->
 	<ItemGroup>
-		<PackageVersion Include="coverlet.collector" Version="6.0.2" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageVersion Include="Moq.AutoMock" Version="3.0.0" />
-		<PackageVersion Include="NSubstitute" Version="5.1.0" />
-		<PackageVersion Include="Shouldly" Version="4.2.1" />
-		<PackageVersion Include="xunit" Version="2.9.2" />
-		<PackageVersion Include="xunit.extensibility.execution" Version="2.9.2" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageVersion Include="Moq.AutoMock" Version="3.5.0" />
+		<PackageVersion Include="NSubstitute" Version="5.3.0" />
+		<PackageVersion Include="Shouldly" Version="4.3.0" />
+		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
 	</ItemGroup>
 
 	<!-- Fody -->
 	<ItemGroup>
 		<PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" />
-		<PackageVersion Include="Fody" Version="6.8.0" />
+		<PackageVersion Include="Fody" Version="6.9.2" />
 	</ItemGroup>
 
 	<!-- Other -->
@@ -466,33 +466,33 @@
 		<PackageVersion Include="aliyun-net-sdk-core" Version="1.5.10" />
 		<PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.14.1" />
 		<PackageVersion Include="AgileConfig.Client" Version="1.6.9" />
-		<PackageVersion Include="Dapr.Client" Version="1.14.0" />
-		<PackageVersion Include="Dapr.Actors" Version="1.14.0" />
-		<PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.14.0" />
-		<PackageVersion Include="DistributedLock.Core" Version="1.0.7" />
+		<PackageVersion Include="Dapr.Client" Version="1.15.4" />
+		<PackageVersion Include="Dapr.Actors" Version="1.15.4" />
+		<PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.15.4" />
+		<PackageVersion Include="DistributedLock.Core" Version="1.0.8" />
 		<PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
 		<PackageVersion Include="Hangfire.MySqlStorage" Version="2.0.3" />
-		<PackageVersion Include="HangFire.SqlServer" Version="1.8.17" />
+		<PackageVersion Include="HangFire.SqlServer" Version="1.8.18" />
 		<PackageVersion Include="IdentityModel" Version="7.0.0" />
-		<PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
+		<PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
 		<PackageVersion Include="Markdig" Version="0.34.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageVersion Include="NEST" Version="7.17.5" />
 		<PackageVersion Include="NRules" Version="0.9.2" />
 		<PackageVersion Include="Ocelot.Provider.Polly" Version="20.0.0" />
-		<PackageVersion Include="Polly" Version="8.4.2" />
-		<PackageVersion Include="Quartz.Serialization.Json" Version="3.13.0" />
+		<PackageVersion Include="Polly" Version="8.5.2" />
+		<PackageVersion Include="Quartz.Serialization.Json" Version="3.14.0" />
 		<PackageVersion Include="RulesEngine" Version="5.0.5" />
 		<PackageVersion Include="Senparc.Weixin.MP" Version="16.18.9" />
-		<PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
-		<PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
-		<PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
-		<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+		<PackageVersion Include="SixLabors.ImageSharp" Version="3.1.8" />
+		<PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
+		<PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
+		<PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />
 		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
 		<PackageVersion Include="Tencent.QCloud.Cos.Sdk" Version="5.4.37" />
 		<PackageVersion Include="TencentCloudSDK" Version="3.0.712" />
 		<PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />
-		<PackageVersion Include="OpenIddict.Server.DataProtection" Version="6.0.0" />
-		<PackageVersion Include="OpenIddict.Validation.DataProtection" Version="6.0.0" />
+		<PackageVersion Include="OpenIddict.Server.DataProtection" Version="6.2.1" />
+		<PackageVersion Include="OpenIddict.Validation.DataProtection" Version="6.2.1" />
 	</ItemGroup>
 </Project>

--- a/aspnet-core/templates/micro/content/common.props
+++ b/aspnet-core/templates/micro/content/common.props
@@ -1,12 +1,12 @@
 <Project>
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
-		<Version>9.1.1</Version>
+		<Version>9.2.0</Version>
 		<Authors>colin</Authors>
 		<NoWarn>$(NoWarn);CS1591;CS0436;CS8618;NU1803</NoWarn>
 		<PackageProjectUrl>https://github.com/colinin/abp-next-admin</PackageProjectUrl>
 		<PackageOutputPath>$(SolutionDir)LocalNuget</PackageOutputPath>
-		<PackageVersion>9.1.1</PackageVersion>
+		<PackageVersion>9.2.0</PackageVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/colinin/abp-next-admin</RepositoryUrl>
@@ -32,6 +32,10 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<OutputPath>$(SolutionDir)LocalNuget</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<OutputPath>$(SolutionDir)LocalNuget</OutputPath>
 	</PropertyGroup>
 

--- a/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/PackageName.CompanyName.ProjectName.HttpApi.Host.csproj
+++ b/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/PackageName.CompanyName.ProjectName.HttpApi.Host.csproj
@@ -15,8 +15,8 @@
 		<PackageReference Include="DotNetCore.CAP.PostgreSql" Condition="'$(PostgreSql)'=='true'" />
 		<PackageReference Include="DotNetCore.CAP.Sqlite" Condition="'$(Sqlite)'=='true'" />
 		<PackageReference Include="DotNetCore.CAP.RabbitMQ" />
+		<PackageReference Include="LINGYUN.Abp.Claims.Mapping" />
 		<PackageReference Include="LINGYUN.Abp.AspNetCore.HttpOverrides" />
-		<PackageReference Include="LINGYUN.Abp.AspNetCore.Mvc.Localization" />
 		<PackageReference Include="LINGYUN.Abp.AspNetCore.Mvc.Wrapper" />
 		<PackageReference Include="LINGYUN.Abp.AuditLogging.Elasticsearch" />
 		<PackageReference Include="LINGYUN.Abp.Data.DbMigrator" />
@@ -60,8 +60,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <ProjectReference Include="..\..\migrations\PackageName.CompanyName.ProjectName.DbMigrator.EntityFrameworkCore\PackageName.CompanyName.ProjectName.DbMigrator.EntityFrameworkCore.csproj" />
 	  <ProjectReference Include="..\..\src\PackageName.CompanyName.ProjectName.Application\PackageName.CompanyName.ProjectName.Application.csproj" />
-	  <ProjectReference Include="..\..\src\PackageName.CompanyName.ProjectName.EntityFrameworkCore\PackageName.CompanyName.ProjectName.EntityFrameworkCore.csproj" />
 	  <ProjectReference Include="..\..\src\PackageName.CompanyName.ProjectName.HttpApi\PackageName.CompanyName.ProjectName.HttpApi.csproj" />
 	  <ProjectReference Include="..\..\src\PackageName.CompanyName.ProjectName.SettingManagement\PackageName.CompanyName.ProjectName.SettingManagement.csproj" />
 	</ItemGroup>

--- a/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/ProjectNameHttpApiHostModule.Configure.cs
+++ b/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/ProjectNameHttpApiHostModule.Configure.cs
@@ -7,6 +7,7 @@ using LINGYUN.Abp.Localization.CultureMap;
 using LINGYUN.Abp.LocalizationManagement;
 using LINGYUN.Abp.Serilog.Enrichers.Application;
 using LINGYUN.Abp.Serilog.Enrichers.UniqueId;
+using LINGYUN.Abp.TextTemplating;
 using LINGYUN.Abp.Wrapper;
 using Medallion.Threading;
 using Medallion.Threading.Redis;
@@ -18,10 +19,11 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
-using PackageName.CompanyName.ProjectName.Localization;
 using StackExchange.Redis;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
@@ -30,13 +32,16 @@ using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.AntiForgery;
 using Volo.Abp.Auditing;
 using Volo.Abp.Caching;
+using Volo.Abp.FeatureManagement;
 using Volo.Abp.GlobalFeatures;
 using Volo.Abp.Http.Client;
 using Volo.Abp.Json;
 using Volo.Abp.Json.SystemTextJson;
 using Volo.Abp.Localization;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.PermissionManagement;
 using Volo.Abp.Security.Claims;
+using Volo.Abp.SettingManagement;
 using Volo.Abp.Threading;
 using Volo.Abp.Timing;
 using Volo.Abp.VirtualFileSystem;
@@ -46,7 +51,6 @@ namespace PackageName.CompanyName.ProjectName;
 public partial class ProjectNameHttpApiHostModule
 {
     public static string ApplicationName { get; set; } = "ProjectNameService";
-    private const string DefaultCorsPolicyName = "Default";
     private static readonly OneTimeRunner OneTimeRunner = new();
 
     private void PreConfigureFeature()
@@ -235,6 +239,54 @@ public partial class ProjectNameHttpApiHostModule
         });
     }
 
+    private void ConfigureFeatureManagement(IConfiguration configuration)
+    {
+        if (configuration.GetValue("FeatureManagement:IsDynamicStoreEnabled", false))
+        {
+            Configure<FeatureManagementOptions>(options =>
+            {
+                options.SaveStaticFeaturesToDatabase = true;
+                options.IsDynamicFeatureStoreEnabled = true;
+            });
+        }
+    }
+
+    private void ConfigurePermissionManagement(IConfiguration configuration)
+    {
+        if (configuration.GetValue("PermissionManagement:IsDynamicStoreEnabled", false))
+        {
+            Configure<PermissionManagementOptions>(options =>
+            {
+                options.SaveStaticPermissionsToDatabase = true;
+                options.IsDynamicPermissionStoreEnabled = true;
+            });
+        }
+    }
+
+    private void ConfigureTextTemplatingManagement(IConfiguration configuration)
+    {
+        if (configuration.GetValue("TextTemplatingManagement:IsDynamicStoreEnabled", false))
+        {
+            Configure<AbpTextTemplatingCachingOptions>(options =>
+            {
+                options.SaveStaticTemplateDefinitionToDatabase = true;
+                options.IsDynamicTemplateDefinitionStoreEnabled = true;
+            });
+        }
+    }
+
+    private void ConfigureSettingManagement(IConfiguration configuration)
+    {
+        if (configuration.GetValue("SettingManagement:IsDynamicStoreEnabled", false))
+        {
+            Configure<SettingManagementOptions>(options =>
+            {
+                options.SaveStaticSettingsToDatabase = true;
+                options.IsDynamicSettingStoreEnabled = true;
+            });
+        }
+    }
+
     private void ConfigureVirtualFileSystem()
     {
         Configure<AbpVirtualFileSystemOptions>(options =>
@@ -294,10 +346,11 @@ public partial class ProjectNameHttpApiHostModule
                         }
                 });
                 options.OperationFilter<TenantHeaderParamter>();
+                options.HideAbpEndpoints();
             });
     }
 
-    private void ConfigureLocalization()
+    private void ConfigureLocalization(IConfiguration configuration)
     {
         // 支持本地化语言类型
         Configure<AbpLocalizationOptions>(options =>
@@ -318,10 +371,13 @@ public partial class ProjectNameHttpApiHostModule
             options.UiCulturesMaps.Add(zhHansCultureMapInfo);
         });
 
-        Configure<AbpLocalizationManagementOptions>(options =>
+        if (configuration.GetValue("LocalizationManagement:IsDynamicStoreEnabled", false))
         {
-            options.SaveStaticLocalizationsToDatabase = true;
-        });
+            Configure<AbpLocalizationManagementOptions>(options =>
+            {
+                options.SaveStaticLocalizationsToDatabase = true;
+            });
+        }
     }
 
     private void ConfigureSecurity(IServiceCollection services, IConfiguration configuration, bool isDevelopment = false)
@@ -333,9 +389,16 @@ public partial class ProjectNameHttpApiHostModule
         });
 
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
+            .AddAbpJwtBearer(options =>
             {
                 configuration.GetSection("AuthServer").Bind(options);
+
+                var validIssuers = configuration.GetSection("AuthServer:ValidIssuers").Get<List<string>>();
+                if (validIssuers?.Count > 0)
+                {
+                    options.TokenValidationParameters.ValidIssuers = validIssuers;
+                    options.TokenValidationParameters.IssuerValidator = TokenWildcardIssuerValidator.IssuerValidator;
+                }
             });
 
         if (!isDevelopment)
@@ -352,7 +415,7 @@ public partial class ProjectNameHttpApiHostModule
     {
         services.AddCors(options =>
         {
-            options.AddPolicy(DefaultCorsPolicyName, builder =>
+            options.AddDefaultPolicy(builder =>
             {
                 builder
                     .WithOrigins(

--- a/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/ProjectNameHttpApiHostModule.cs
+++ b/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/ProjectNameHttpApiHostModule.cs
@@ -1,6 +1,7 @@
 using LINGYUN.Abp.AspNetCore.HttpOverrides;
 using LINGYUN.Abp.AspNetCore.Mvc.Wrapper;
 using LINGYUN.Abp.AuditLogging.Elasticsearch;
+using LINGYUN.Abp.Claims.Mapping;
 using LINGYUN.Abp.Emailing.Platform;
 using LINGYUN.Abp.EventBus.CAP;
 using LINGYUN.Abp.ExceptionHandling.Emailing;
@@ -44,20 +45,24 @@ namespace PackageName.CompanyName.ProjectName;
     typeof(AbpSerilogEnrichersUniqueIdModule),
     typeof(AbpAuditLoggingElasticsearchModule),
     typeof(AbpAspNetCoreSerilogModule),
+
     typeof(ProjectNameApplicationModule),
     typeof(ProjectNameHttpApiModule),
-    typeof(ProjectNameEntityFrameworkCoreModule),
     typeof(ProjectNameSettingManagementModule),
+    typeof(ProjectNameDbMigratorEntityFrameworkCoreModule),
+
     typeof(AbpEmailingExceptionHandlingModule),
     typeof(AbpCAPEventBusModule),
     typeof(AbpHttpClientIdentityModelWebModule),
     typeof(AbpAspNetCoreMultiTenancyModule),
+
     typeof(AbpSaasEntityFrameworkCoreModule),
     typeof(AbpFeatureManagementEntityFrameworkCoreModule),
     typeof(AbpPermissionManagementEntityFrameworkCoreModule),
     typeof(AbpSettingManagementEntityFrameworkCoreModule),
     typeof(AbpLocalizationManagementEntityFrameworkCoreModule),
     typeof(AbpTextTemplatingEntityFrameworkCoreModule),
+
     typeof(AbpAspNetCoreAuthenticationJwtBearerModule),
     typeof(AbpCachingStackExchangeRedisModule),
     typeof(AbpDistributedLockingModule),
@@ -69,6 +74,7 @@ namespace PackageName.CompanyName.ProjectName;
 #elif OpenTelemetry
     typeof(AbpTelemetryOpenTelemetryModule),
 #endif
+    typeof(AbpClaimsMappingModule),
     typeof(AbpExporterMiniExcelModule),
     typeof(AbpEmailingPlatformModule),
     typeof(AbpSmsPlatformModule),
@@ -94,7 +100,6 @@ public partial class ProjectNameHttpApiHostModule : AbpModule
 
         ConfigureWrapper();
         ConfigureMiniExcel();
-        ConfigureLocalization();
         ConfigureExceptionHandling();
         ConfigureVirtualFileSystem();
         ConfigureTiming(configuration);
@@ -103,6 +108,13 @@ public partial class ProjectNameHttpApiHostModule : AbpModule
         ConfigureIdentity(configuration);
         ConfigureMultiTenancy(configuration);
         ConfigureJsonSerializer(configuration);
+
+        ConfigureLocalization(configuration);
+        ConfigureFeatureManagement(configuration);
+        ConfigureSettingManagement(configuration);
+        ConfigurePermissionManagement(configuration);
+        ConfigureTextTemplatingManagement(configuration);
+
         ConfigureSwagger(context.Services);
         ConfigureMvc(context.Services, configuration);
         ConfigureCors(context.Services, configuration);

--- a/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/appsettings.Development.json
+++ b/aspnet-core/templates/micro/content/host/PackageName.CompanyName.ProjectName.HttpApi.Host/appsettings.Development.json
@@ -143,6 +143,22 @@
     "SwaggerClientId": "InternalServiceClient",
     "SwaggerClientSecret": "1q2w3E*"
   },
+
+  "FeatureManagement": {
+    "IsDynamicStoreEnabled": true
+  },
+  "SettingManagement": {
+    "IsDynamicStoreEnabled": true
+  },
+  "PermissionManagement": {
+    "IsDynamicStoreEnabled": true
+  },
+  "LocalizationManagement": {
+    "IsDynamicStoreEnabled": true
+  },
+  "TextTemplating": {
+    "IsDynamicStoreEnabled": true
+  },
   "Logging": {
     "Serilog": {
       "Elasticsearch": {

--- a/aspnet-core/templates/micro/content/migrations/migrations-database.ps1
+++ b/aspnet-core/templates/micro/content/migrations/migrations-database.ps1
@@ -12,4 +12,6 @@ Set-Location ../PackageName.CompanyName.ProjectName.DbMigrator
 
 dotnet run
 
+Set-Location ../
+
 Write-host "[ProjectName] - seed data successfuly completed."


### PR DESCRIPTION
… 9.2.0

- 修复 `CORS` 配置错误
- 使用 `AddAbpJwtBearer` 处理身份认证失败方案
- 增加 `ValidIssuers` 配置项以支持泛域名身份认证
- 动态设置、功能、权限、模板、本地化通过配置项决定是否启用
- 在 `Swagger` 中隐藏abp端点
- 引用EfCore迁移项目以支持租户事件
- 移除 Mvc 本地化端点模块
- 修复身份认证验证失败(强制重写AbpClaimTypes与JWT保持转一致)
- 更新 `common.props`
- 更新 `Directory.Packages.props`
- 更新模板版本号