### PR TITLE
fix(text-template): Fix the rendering error of the text content

### DIFF
--- a/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/TextTemplateContentProvider.cs
+++ b/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/TextTemplateContentProvider.cs
@@ -30,8 +30,12 @@ public class TextTemplateContentProvider : TemplateContentProvider, ITransientDe
         bool tryDefaults = true, 
         bool useCurrentCultureIfCultureNameIsNull = true)
     {
-        var template = await TemplateDefinitionStore.GetAsync(templateName);
+        var template = await TemplateDefinitionStore.GetOrNullAsync(templateName);
+        if (template != null)
+        {
+            return await GetContentOrNullAsync(template, cultureName);
+        }
 
-        return await GetContentOrNullAsync(template, cultureName);
+        return await base.GetContentOrNullAsync(templateName, cultureName, tryDefaults, useCurrentCultureIfCultureNameIsNull);
     }
 }

--- a/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/TextTemplateDefinitionInitializer.cs
+++ b/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/TextTemplateDefinitionInitializer.cs
@@ -36,7 +36,7 @@ public class TextTemplateDefinitionInitializer : ITransientDependency
         using var scope = RootServiceProvider.CreateScope();
         var applicationLifetime = scope.ServiceProvider.GetService<IHostApplicationLifetime>();
         var token = applicationLifetime?.ApplicationStopping ?? cancellationToken;
-        using (CancellationTokenProvider.Use(cancellationToken))
+        using (CancellationTokenProvider.Use(token))
         {
             if (CancellationTokenProvider.Token.IsCancellationRequested)
             {


### PR DESCRIPTION
- roll back to the default culture, if specified culture template is empty
- If the dynamic template definition query is empty, fall back to the static template definition